### PR TITLE
Implement XP progress bar and orientation lock

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <canvas id="game"></canvas>
   <div id="ui">
     <div id="hp"></div>
-    <div id="xp"></div>
+    <div id="xp"><div id="xp-bar"></div></div>
     <div id="glitch"></div>
   </div>
   <button id="force-glitch" hidden>Force Glitch</button>

--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,19 @@ body {
   padding: 2px;
 }
 
+#xp {
+  height: 4px;
+  background: rgba(255,255,255,0.1);
+  position: relative;
+  width: 100%;
+}
+
+#xp-bar {
+  height: 100%;
+  width: 0%;
+  background: currentColor;
+}
+
 #force-glitch {
   position: fixed;
   bottom: 5px;


### PR DESCRIPTION
## Summary
- add XP progress bar element and styling
- lock orientation to portrait if supported
- recalc difficulty every 10 seconds
- update XP bar width every frame

## Testing
- `node --check game.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686244ab31208332a3a6e7717a6593cf