### PR TITLE
Add chance-based boss spawn

### DIFF
--- a/game.js
+++ b/game.js
@@ -287,8 +287,10 @@ function calcDifficulty(dt){
   if(player.dps>1.4*expDPS){
     highDpsTime += dt;
     if(highDpsTime>60000 && glitchCountdown===0){
-      spawnGlitchBoss();
-      highDpsTime=0;
+      if(Math.random()<0.3){
+        spawnGlitchBoss();
+        highDpsTime=0;
+      }
     }
   } else highDpsTime = Math.max(0,highDpsTime-dt);
 }


### PR DESCRIPTION
## Summary
- spawn glitch boss with a 30% chance once DPS stays high
- keep the timer running if chance fails so later checks can happen

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_686249d65f18833290bf117add086d27