### PR TITLE
Add orientation warning overlay

### DIFF
--- a/game.js
+++ b/game.js
@@ -19,11 +19,27 @@ const finalStatsEl = document.getElementById('final-stats');
 const restartBtn = document.getElementById('restart');
 const glyphsEl = document.getElementById('glyphs');
 const glitchBtn = document.getElementById('force-glitch');
+const rotateWarningEl = document.getElementById('rotate-warning');
 const devMode = new URLSearchParams(location.search).get('dev') === '1';
 if (devMode) glitchBtn.hidden = false;
+let orientationLockFailed = false;
 // try locking to portrait
 if (screen.orientation && screen.orientation.lock) {
-  screen.orientation.lock('portrait').catch(() => {});
+  screen.orientation.lock('portrait').catch(() => {
+    orientationLockFailed = true;
+    checkOrientation();
+  });
+} else {
+  orientationLockFailed = true;
+}
+
+function checkOrientation() {
+  if (!orientationLockFailed) return;
+  if (window.innerWidth > window.innerHeight) {
+    rotateWarningEl.hidden = false;
+  } else {
+    rotateWarningEl.hidden = true;
+  }
 }
 
 function resize() {
@@ -34,8 +50,10 @@ function resize() {
   canvas.style.width = width + 'px';
   canvas.style.height = height + 'px';
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  checkOrientation();
 }
 window.addEventListener('resize', resize);
+window.addEventListener('orientationchange', checkOrientation);
 resize();
 
 // ==== game state =====

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     <div id="final-stats"></div>
     <button id="restart">Restart</button>
   </div>
+  <div id="rotate-warning" class="overlay" hidden>Rotate device to portrait</div>
   <button id="force-glitch" hidden>Force Glitch</button>
   <script type="module" src="game.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -75,3 +75,8 @@ body {
   text-shadow: 0 0 4px currentColor;
   pointer-events: auto;
 }
+
+#rotate-warning {
+  color: #fff;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- warn users to rotate their device if landscape
- style rotate warning overlay
- show/hide warning based on orientation and screen lock failure

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68624bc9d3b08332b3280386f90271c3