### PR TITLE
Add controls hint to start screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,10 @@
     <div id="glyphs"></div>
     <div id="glitch"></div>
   </div>
-  <div id="start-screen" class="overlay">TAP TO START</div>
+  <div id="start-screen" class="overlay">
+    <div>TAP TO START</div>
+    <div class="controls">Swipe or use arrows to move; tap loot to collect</div>
+  </div>
   <div id="game-over" class="overlay" hidden>
     <div id="final-stats"></div>
     <button id="restart">Restart</button>

--- a/styles.css
+++ b/styles.css
@@ -69,11 +69,13 @@ body {
   width: 100%;
   height: 100%;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   background: rgba(0,0,0,0.8);
   text-shadow: 0 0 4px currentColor;
   pointer-events: auto;
+  text-align: center;
 }
 
 #rotate-warning {


### PR DESCRIPTION
## Summary
- show basic control instructions on the start screen
- adjust overlay styles so stacked elements stay centered

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68626e9e3aec83329f760fa12c951a69