### PR TITLE
Improve desktop controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ For the complete game specification see [aboutthegame.txt](aboutthegame.txt).
 
 ## Controls
 - Swipe or use WASD/arrow keys to move the player.
-- Tap/click loot symbols to pick them up.
-- When HP reaches zero a restart button will appear.
+- Tap/click loot symbols or press the SPACE key to pick them up on desktop.
+- When HP reaches zero a restart button will appear. Press Enter to start a new run.
 
 GLITCH RUNNER — это портретный, бесконечный браузер-рогалик, выглядящий как взломанный кассетный автомат, который сыпет неоном и цифровым хаосом. Вид сверху: ты — крошечный белый круг-курсор, скользящий по бездонной сетке процедурно зашитого мегаполиса. Город сам рождается из патчей: квартире-битовые блоки, туннели-шины, площади-матрицы — всё стыкуется на лету по шумовому сиду, поэтому знакомых улиц не бывает даже в одном забеге. Управление предельно голое: один стик или свайп двигает игрока, вторая рука свободна — стрельба, подбор лута и все спецэффекты происходят автоматом в направлении движения камеры, никаких дополнительных кнопок и HUD-меню, только крошечный счётчик волн в углу, который тает, когда экран начинает глючить.
 

--- a/game.js
+++ b/game.js
@@ -24,19 +24,23 @@ const joystickEl = document.getElementById('joystick');
 const stickEl = document.getElementById('stick');
 const waveEl = document.getElementById('wave');
 const staticEl = document.getElementById('static-overlay');
+const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 const devMode = new URLSearchParams(location.search).get('dev') === '1';
 if (devMode) glitchBtn.hidden = false;
+if (!isMobile) joystickEl.style.display = 'none';
 
-// lock to portrait when possible
-if (screen.orientation && screen.orientation.lock) {
-  screen.orientation.lock('portrait').catch(() => {});
-}
-
-const orientationMedia = window.matchMedia
-  ? window.matchMedia('(orientation: portrait)')
-  : null;
-if (orientationMedia && orientationMedia.addEventListener) {
-  orientationMedia.addEventListener('change', checkOrientation);
+// lock to portrait on mobile when possible
+let orientationMedia = null;
+if (isMobile) {
+  if (screen.orientation && screen.orientation.lock) {
+    screen.orientation.lock('portrait').catch(() => {});
+  }
+  orientationMedia = window.matchMedia
+    ? window.matchMedia('(orientation: portrait)')
+    : null;
+  if (orientationMedia && orientationMedia.addEventListener) {
+    orientationMedia.addEventListener('change', checkOrientation);
+  }
 }
 
 function isPortrait() {
@@ -48,6 +52,10 @@ function isPortrait() {
 }
 
 function checkOrientation() {
+  if (!isMobile) {
+    rotateWarningEl.hidden = true;
+    return;
+  }
   rotateWarningEl.hidden = isPortrait();
 }
 
@@ -62,7 +70,7 @@ function resize() {
   checkOrientation();
 }
 window.addEventListener('resize', resize);
-window.addEventListener('orientationchange', checkOrientation);
+if (isMobile) window.addEventListener('orientationchange', checkOrientation);
 resize();
 
 // ==== game state =====
@@ -573,6 +581,11 @@ restartBtn.addEventListener('click',startGame);
 document.addEventListener('keydown',e=>{
   keys[e.key]=true;
   if(e.key==='Enter' && !running) startGame();
+  if(e.key===' ' && running) {
+    loot.forEach(l=>{
+      if(!l.dead && distSq(l,player)<400) collectLoot(l);
+    });
+  }
 });
 document.addEventListener('keyup',e=>{ keys[e.key]=false; });
 

--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
     <div id="wave"></div>
   </div>
   <div id="start-screen" class="overlay">
-    <div>TAP TO START</div>
-    <div class="controls">Swipe or use arrows to move; tap loot to collect</div>
+    <div>TAP OR PRESS ENTER TO START</div>
+    <div class="controls">Swipe or use arrows/WASD to move; click or press SPACE to collect loot</div>
   </div>
   <div id="game-over" class="overlay" hidden>
     <div id="final-stats"></div>


### PR DESCRIPTION
## Summary
- add desktop detection and disable mobile orientation checks
- hide mobile joystick on desktop
- allow picking up loot with space bar
- update start screen and README with new desktop controls

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6862e07ade5c83328da1fe8d50f07e74