### PR TITLE
Add glitch event with phantom enemies

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -124,3 +124,7 @@ body {
   from { transform: translate(0,0); }
   to { transform: translate(-50px,50px); }
 }
+
+@keyframes glitchHue { from { filter: invert(1) hue-rotate(0deg); } to { filter: invert(1) hue-rotate(360deg); } }
+body.glitch-event { animation: glitchHue 0.3s steps(2) infinite; }
+


### PR DESCRIPTION
## Summary
- implement `startGlitchEvent()` and `endGlitchEvent()`
- spawn phantom enemies and use bit-crush audio / shader effects during glitch event
- apply penalty on failure for next run
- handle penalty and cooldown overrides
- style glitch event with color inversion

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_6862e204103883329a9e267eb475b35b